### PR TITLE
Add grab-screen CLI with preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 - Save screenshots in a dedicated `Pictures/FLICKERs` folder for effortless organization.
 - Support for both X11 and Wayland display servers.
 - Intuitive keyboard shortcuts for lightning-fast capture:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F9): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F10): Capture the current window
+    - WIN + Shift + D (or ALT + Shift + D / F11): Capture the entire screen
 
 **Installation:**
 
@@ -33,9 +33,24 @@
    python -m flicker.app
    ```
 2. Use the keyboard shortcuts to capture screenshots:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F9): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F10): Capture the current window
+    - WIN + Shift + D (or ALT + Shift + D / F11): Capture the entire screen
+
+You can also call ``grab-screen`` directly for one-off captures. By default it
+lets you select a region and then opens the result with your desktop image
+viewer. Use ``--full`` or ``--window`` to change the mode.
+
+### Running as a background service
+
+Copy ``flicker.service`` to ``~/.config/systemd/user/`` and enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now flicker.service
+```
+
+This starts the hotkey listener automatically on login.
 
 **Planned Features:**
 

--- a/flicker.service
+++ b/flicker.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Flicker screenshot hotkey service
+
+[Service]
+ExecStart=/usr/bin/python3 -m flicker.app
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/flicker/README.md
+++ b/flicker/README.md
@@ -12,9 +12,9 @@
 - Save screenshots in a dedicated `Pictures/FLICKERs` folder for effortless organization.
 - Support for both X11 and Wayland display servers.
 - Intuitive keyboard shortcuts for lightning-fast capture:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F9): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F10): Capture the current window
+    - WIN + Shift + D (or ALT + Shift + D / F11): Capture the entire screen
 
 **Installation:**
 
@@ -35,9 +35,23 @@
    python -m flicker.app
    ```
 2. Use the keyboard shortcuts to capture screenshots:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F9): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F10): Capture the current window
+    - WIN + Shift + D (or ALT + Shift + D / F11): Capture the entire screen
+
+Alternatively run ``grab-screen`` for a quick capture and preview. It defaults
+to selection mode but supports ``--full`` and ``--window`` options.
+
+### Running as a background service
+
+Copy ``flicker.service`` to ``~/.config/systemd/user/`` and enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now flicker.service
+```
+
+This starts the hotkey listener automatically on login.
 
 **Planned Features:**
 

--- a/flicker/grab_screen.py
+++ b/flicker/grab_screen.py
@@ -1,0 +1,22 @@
+import argparse
+from .screenshot import capture_selection, capture_full_screen, capture_screen
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Take a screenshot")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-f', '--full', action='store_true', help='Grab the entire screen')
+    group.add_argument('-w', '--window', action='store_true', help='Grab the current window')
+    group.add_argument('-s', '--selection', action='store_true', help='Grab a selection (default)')
+    args = parser.parse_args()
+
+    if args.full:
+        capture_full_screen()
+    elif args.window:
+        capture_screen()
+    else:
+        capture_selection()
+
+
+if __name__ == '__main__':
+    main()

--- a/flicker/keyboard_listener.py
+++ b/flicker/keyboard_listener.py
@@ -7,16 +7,30 @@ current_keys = set()
 def on_press(key):
     current_keys.add(key)
 
-    if {keyboard.Key.alt_l, keyboard.Key.shift,
-        keyboard.KeyCode.from_char('s')} <= current_keys or key == keyboard.Key.f9:
+    # Windows-like shortcut: Win + Shift + S
+    if {keyboard.Key.cmd, keyboard.Key.shift,
+        keyboard.KeyCode.from_char('s')} <= current_keys:
+        print("Capturing selection...")
+        capture_selection()
+    # Legacy shortcut: Alt + Shift + S or F9
+    elif {keyboard.Key.alt_l, keyboard.Key.shift,
+          keyboard.KeyCode.from_char('s')} <= current_keys or key == keyboard.Key.f9:
         print("Capturing selection...")
         capture_selection()
 
+    elif {keyboard.Key.cmd, keyboard.Key.shift,
+          keyboard.KeyCode.from_char('w')} <= current_keys:
+        print("Capturing screen...")
+        capture_screen()
     elif {keyboard.Key.alt_l, keyboard.Key.shift,
           keyboard.KeyCode.from_char('w')} <= current_keys or key == keyboard.Key.f10:
         print("Capturing screen...")
         capture_screen()
 
+    elif {keyboard.Key.cmd, keyboard.Key.shift,
+          keyboard.KeyCode.from_char('d')} <= current_keys:
+        print("Capturing full screen...")
+        capture_full_screen()
     elif {keyboard.Key.alt_l, keyboard.Key.shift,
           keyboard.KeyCode.from_char('d')} <= current_keys or key == keyboard.Key.f11:
         print("Capturing full screen...")

--- a/flicker/screenshot.py
+++ b/flicker/screenshot.py
@@ -6,6 +6,24 @@ from datetime import datetime
 from PyQt5.QtWidgets import QApplication
 
 
+def _open_file(filepath: str) -> None:
+    """Try to open ``filepath`` with a desktop image viewer.
+
+    This function attempts ``xdg-open`` (Linux) or ``open`` (macOS). If
+    neither is available the path is printed so the user can open it
+    manually.
+    """
+    print(f"Screenshot saved as {filepath}")
+    commands = [['xdg-open', filepath], ['open', filepath]]
+    for cmd in commands:
+        try:
+            subprocess.Popen(cmd)
+            return
+        except FileNotFoundError:
+            continue
+    print("Unable to automatically open the screenshot.")
+
+
 def get_session_type():
     print(os.getenv('XDG_SESSION_TYPE'))
     return os.getenv('XDG_SESSION_TYPE')
@@ -33,7 +51,7 @@ def capture_full_screen():
         return
 
     subprocess.run(cmd)
-    print(f"Full screen screenshot saved as {full_path}")
+    _open_file(full_path)
 
 
 def capture_selection():
@@ -50,7 +68,7 @@ def capture_selection():
         print("Unsupported session type.")
         return
 
-    print(f"Selection screenshot saved as {full_path}")
+    _open_file(full_path)
 
 
 def capture_screen():
@@ -76,7 +94,7 @@ def capture_screen():
     screenshot = screen.grabWindow(0)
     screenshot.save(full_path, 'png')
 
-    print(f"Screenshot saved as {full_path}")
+    _open_file(full_path)
 
 
 if __name__ == "__main__":

--- a/grab-screen
+++ b/grab-screen
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from flicker.grab_screen import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add helper to open screenshots automatically
- preview captured images from all capture functions
- implement grab-screen CLI for one-off screenshot captures
- document `grab-screen` usage
- support Windows-style hotkeys and add a systemd service

## Testing
- `python -m py_compile flicker/*.py grab-screen`


------
https://chatgpt.com/codex/tasks/task_e_684f4f30856c8333b5d15536703f9422