### PR TITLE
Improve hotkeys and screenshot fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 - Save screenshots in a dedicated `Pictures/FLICKERs` folder for effortless organization.
 - Support for both X11 and Wayland display servers.
 - Intuitive keyboard shortcuts for lightning-fast capture:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F6): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F9): Capture the focused window
+    - F7: Capture the screen under the cursor
+    - WIN + Shift + D (or ALT + Shift + D / F8): Capture all screens
 
 **Installation:**
 
@@ -33,9 +34,25 @@
    python -m flicker.app
    ```
 2. Use the keyboard shortcuts to capture screenshots:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F6): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F9): Capture the focused window
+    - F7: Capture the screen under the cursor
+    - WIN + Shift + D (or ALT + Shift + D / F8): Capture all screens
+
+You can also call ``grab-screen`` directly for one-off captures. By default it
+lets you select a region and then opens the result with your desktop image
+viewer. Use ``--full``, ``--screen`` or ``--window`` to change the mode.
+
+### Running as a background service
+
+Copy ``flicker.service`` to ``~/.config/systemd/user/`` and enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now flicker.service
+```
+
+This starts the hotkey listener automatically on login.
 
 **Planned Features:**
 

--- a/flicker.service
+++ b/flicker.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Flicker screenshot hotkey service
+
+[Service]
+ExecStart=/usr/bin/python3 -m flicker.app
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/flicker/README.md
+++ b/flicker/README.md
@@ -12,9 +12,10 @@
 - Save screenshots in a dedicated `Pictures/FLICKERs` folder for effortless organization.
 - Support for both X11 and Wayland display servers.
 - Intuitive keyboard shortcuts for lightning-fast capture:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F6): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F9): Capture the focused window
+    - F7: Capture the screen under the cursor
+    - WIN + Shift + D (or ALT + Shift + D / F8): Capture all screens
 
 **Installation:**
 
@@ -35,9 +36,24 @@
    python -m flicker.app
    ```
 2. Use the keyboard shortcuts to capture screenshots:
-    - ALT + Shift + S (F9): Capture a selection
-    - ALT + Shift + W (F10): Capture the current window
-    - ALT + Shift + D (F11): Capture the entire screen
+    - WIN + Shift + S (or ALT + Shift + S / F6): Capture a selection
+    - WIN + Shift + W (or ALT + Shift + W / F9): Capture the focused window
+    - F7: Capture the screen under the cursor
+    - WIN + Shift + D (or ALT + Shift + D / F8): Capture all screens
+
+Alternatively run ``grab-screen`` for a quick capture and preview. It defaults
+to selection mode but supports ``--full``, ``--screen`` and ``--window`` options.
+
+### Running as a background service
+
+Copy ``flicker.service`` to ``~/.config/systemd/user/`` and enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now flicker.service
+```
+
+This starts the hotkey listener automatically on login.
 
 **Planned Features:**
 

--- a/flicker/grab_screen.py
+++ b/flicker/grab_screen.py
@@ -1,0 +1,30 @@
+import argparse
+from .screenshot import (
+    capture_selection,
+    capture_full_screen,
+    capture_window,
+    capture_current_screen,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Take a screenshot")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-f', '--full', action='store_true', help='Grab all screens')
+    group.add_argument('-c', '--screen', action='store_true', help='Grab the screen with the cursor')
+    group.add_argument('-w', '--window', action='store_true', help='Grab the focused window')
+    group.add_argument('-s', '--selection', action='store_true', help='Grab a selection (default)')
+    args = parser.parse_args()
+
+    if args.full:
+        capture_full_screen()
+    elif args.screen:
+        capture_current_screen()
+    elif args.window:
+        capture_window()
+    else:
+        capture_selection()
+
+
+if __name__ == '__main__':
+    main()

--- a/flicker/keyboard_listener.py
+++ b/flicker/keyboard_listener.py
@@ -1,37 +1,34 @@
+"""Keyboard hotkey listener for screenshot actions."""
+
 from pynput import keyboard
-from .screenshot import capture_full_screen, capture_selection, capture_screen
 
-current_keys = set()
-
-
-def on_press(key):
-    current_keys.add(key)
-
-    if {keyboard.Key.alt_l, keyboard.Key.shift,
-        keyboard.KeyCode.from_char('s')} <= current_keys or key == keyboard.Key.f9:
-        print("Capturing selection...")
-        capture_selection()
-
-    elif {keyboard.Key.alt_l, keyboard.Key.shift,
-          keyboard.KeyCode.from_char('w')} <= current_keys or key == keyboard.Key.f10:
-        print("Capturing screen...")
-        capture_screen()
-
-    elif {keyboard.Key.alt_l, keyboard.Key.shift,
-          keyboard.KeyCode.from_char('d')} <= current_keys or key == keyboard.Key.f11:
-        print("Capturing full screen...")
-        capture_full_screen()
+from .screenshot import (
+    capture_full_screen,
+    capture_selection,
+    capture_window,
+    capture_current_screen,
+)
 
 
-def on_release(key):
-    try:
-        current_keys.remove(key)
-    except KeyError:
-        pass
+# Hotkeys are registered using the higher level GlobalHotKeys helper so we don't
+# have to track key state manually.
+HOTKEYS = {
+    "<cmd>+<shift>+s": capture_selection,
+    "<cmd>+<shift>+w": capture_window,
+    "<cmd>+<shift>+d": capture_full_screen,
+    "<alt>+<shift>+s": capture_selection,
+    "<alt>+<shift>+w": capture_window,
+    "<alt>+<shift>+d": capture_full_screen,
+    "<f6>": capture_selection,
+    "<f7>": capture_current_screen,
+    "<f8>": capture_full_screen,
+    "<f9>": capture_window,
+}
 
 
-def start_listener():
-    with keyboard.Listener(on_press=on_press, on_release=on_release) as listener:
+def start_listener() -> None:
+    """Start listening for global hotkeys."""
+    with keyboard.GlobalHotKeys(HOTKEYS) as listener:
         listener.join()
 
 

--- a/flicker/keyboard_listener.py
+++ b/flicker/keyboard_listener.py
@@ -1,28 +1,40 @@
-"""Keyboard hotkey listener for screenshot actions."""
+"""Keyboard hotkey listener for screenshot actions.
+
+The actual screenshot grabbing is delegated to the ``grab_screen`` CLI. This
+ensures that any PyQt code runs in a separate process and avoids the common
+``QApplication was not created in the main() thread`` errors.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
 
 from pynput import keyboard
 
-from .screenshot import (
-    capture_full_screen,
-    capture_selection,
-    capture_window,
-    capture_current_screen,
-)
+
+def _spawn_cli(flag: str | None = None) -> None:
+    """Launch the grab-screen CLI in a new process."""
+    cmd = [sys.executable, "-m", "flicker.grab_screen"]
+    if flag:
+        cmd.append(flag)
+    subprocess.Popen(cmd)
 
 
 # Hotkeys are registered using the higher level GlobalHotKeys helper so we don't
-# have to track key state manually.
+# have to track key state manually. Each hotkey simply calls the CLI with the
+# appropriate flag.
 HOTKEYS = {
-    "<cmd>+<shift>+s": capture_selection,
-    "<cmd>+<shift>+w": capture_window,
-    "<cmd>+<shift>+d": capture_full_screen,
-    "<alt>+<shift>+s": capture_selection,
-    "<alt>+<shift>+w": capture_window,
-    "<alt>+<shift>+d": capture_full_screen,
-    "<f6>": capture_selection,
-    "<f7>": capture_current_screen,
-    "<f8>": capture_full_screen,
-    "<f9>": capture_window,
+    "<cmd>+<shift>+s": lambda: _spawn_cli("--selection"),
+    "<cmd>+<shift>+w": lambda: _spawn_cli("--window"),
+    "<cmd>+<shift>+d": lambda: _spawn_cli("--full"),
+    "<alt>+<shift>+s": lambda: _spawn_cli("--selection"),
+    "<alt>+<shift>+w": lambda: _spawn_cli("--window"),
+    "<alt>+<shift>+d": lambda: _spawn_cli("--full"),
+    "<f6>": lambda: _spawn_cli("--selection"),
+    "<f7>": lambda: _spawn_cli("--screen"),
+    "<f8>": lambda: _spawn_cli("--full"),
+    "<f9>": lambda: _spawn_cli("--window"),
 }
 
 

--- a/flicker/screenshot.py
+++ b/flicker/screenshot.py
@@ -1,13 +1,79 @@
+"""Screenshot utilities supporting X11 and Wayland with PyQt fallbacks."""
+
 import os
 import subprocess
 import sys
 from datetime import datetime
+from shutil import which
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import Qt, QPoint, QRect
+from PyQt5.QtGui import QColor, QPainter, QPen, QCursor
+from PyQt5.QtWidgets import QApplication, QWidget
+
+
+def _open_file(filepath: str) -> None:
+    """Try to open ``filepath`` with a desktop image viewer.
+
+    This function attempts ``xdg-open`` (Linux) or ``open`` (macOS). If
+    neither is available the path is printed so the user can open it
+    manually.
+    """
+    print(f"Screenshot saved as {filepath}")
+    commands = [['xdg-open', filepath], ['open', filepath]]
+    for cmd in commands:
+        try:
+            subprocess.Popen(cmd)
+            return
+        except FileNotFoundError:
+            continue
+    print("Unable to automatically open the screenshot.")
+
+
+def _cmd_exists(cmd: str) -> bool:
+    """Return ``True`` if ``cmd`` exists on PATH."""
+    return which(cmd) is not None
+
+
+class _SnipWidget(QWidget):
+    """Simple full-screen overlay for selecting a region."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.begin = QPoint()
+        self.end = QPoint()
+        self.setWindowFlags(Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint)
+        self.setWindowState(self.windowState() | Qt.WindowFullScreen)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setCursor(Qt.CrossCursor)
+
+    def paintEvent(self, event):  # type: ignore[override]
+        painter = QPainter(self)
+        painter.setPen(QPen(Qt.red, 2))
+        painter.fillRect(self.rect(), QColor(0, 0, 0, 100))
+        rect = QRect(self.begin, self.end)
+        painter.fillRect(rect, Qt.transparent)
+        painter.drawRect(rect)
+
+    def mousePressEvent(self, event):  # type: ignore[override]
+        self.begin = event.pos()
+        self.end = self.begin
+        self.update()
+
+    def mouseMoveEvent(self, event):  # type: ignore[override]
+        self.end = event.pos()
+        self.update()
+
+    def mouseReleaseEvent(self, event):  # type: ignore[override]
+        self.end = event.pos()
+        self.close()
+
+    @property
+    def selection(self) -> QRect:
+        return QRect(self.begin, self.end).normalized()
 
 
 def get_session_type():
-    print(os.getenv('XDG_SESSION_TYPE'))
+    """Return the current desktop session type."""
     return os.getenv('XDG_SESSION_TYPE')
 
 
@@ -24,59 +90,92 @@ def capture_full_screen():
     session_type = get_session_type()
     full_path = generate_file_path("full_screen")
 
-    if session_type == 'x11':
-        cmd = ['import', '-window', 'root', full_path]
-    elif session_type == 'wayland':
-        cmd = ['grim', full_path]
+    if session_type == "wayland" and _cmd_exists("grim"):
+        subprocess.run(["grim", full_path])
+    elif session_type == "x11" and _cmd_exists("import"):
+        subprocess.run(["import", "-window", "root", full_path])
     else:
-        print("Unsupported session type.")
-        return
+        # Fallback to PyQt grabbing
+        app = QApplication.instance() or QApplication(sys.argv)
+        screen = app.primaryScreen()
+        screenshot = screen.grabWindow(0)
+        screenshot.save(full_path, "png")
 
-    subprocess.run(cmd)
-    print(f"Full screen screenshot saved as {full_path}")
+    _open_file(full_path)
 
 
 def capture_selection():
     session_type = get_session_type()
     full_path = generate_file_path("selection")
 
-    if session_type == 'x11':
-        cmd = ['import', full_path]
-        subprocess.run(cmd)
-    elif session_type == 'wayland':
+    if session_type == "wayland" and _cmd_exists("grim") and _cmd_exists("slurp"):
         cmd = f'grim -g "$(slurp)" {full_path}'
-        subprocess.run(cmd, shell=True, executable='/bin/bash')
+        subprocess.run(cmd, shell=True, executable="/bin/bash")
+    elif session_type == "x11" and _cmd_exists("import"):
+        subprocess.run(["import", full_path])
     else:
-        print("Unsupported session type.")
-        return
+        app = QApplication.instance() or QApplication(sys.argv)
+        screen = app.primaryScreen()
+        overlay = _SnipWidget()
+        overlay.showFullScreen()
+        app.exec_()
+        rect = overlay.selection
+        if rect.width() and rect.height():
+            screenshot = screen.grabWindow(0, rect.x(), rect.y(), rect.width(), rect.height())
+            screenshot.save(full_path, "png")
+        else:
+            print("Selection cancelled.")
+            return
 
-    print(f"Selection screenshot saved as {full_path}")
+    _open_file(full_path)
 
 
-def capture_screen():
-    session_type = get_session_type()
-
-    if session_type not in ['x11', 'wayland']:
-        print(f"Unsupported session type: {session_type}. This script is designed for X11 and Wayland.")
-        sys.exit(1)
-
-    home_dir = os.path.expanduser('~')
-    save_path = os.path.join(home_dir, 'Pictures', 'FLICKERs')
-
-    os.makedirs(save_path, exist_ok=True)
-
-    timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-    filename = f'screenshot_{timestamp}.png'
-    full_path = os.path.join(save_path, filename)
-
-    app = QApplication.instance()
-    if not app:
-        app = QApplication(sys.argv)
-    screen = app.primaryScreen()
+def capture_current_screen() -> None:
+    """Capture the display containing the mouse pointer."""
+    app = QApplication.instance() or QApplication(sys.argv)
+    cursor_pos = QCursor.pos()
+    screen = app.screenAt(cursor_pos)
+    if screen is None:
+        screen = app.primaryScreen()
+    full_path = generate_file_path("screen")
     screenshot = screen.grabWindow(0)
-    screenshot.save(full_path, 'png')
+    screenshot.save(full_path, "png")
+    _open_file(full_path)
 
-    print(f"Screenshot saved as {full_path}")
+
+def capture_window() -> None:
+    """Capture the currently focused window if possible."""
+    session_type = get_session_type()
+    full_path = generate_file_path("window")
+
+    if session_type == "x11" and _cmd_exists("import") and _cmd_exists("xdotool"):
+        try:
+            win_id = (
+                subprocess.check_output(["xdotool", "getactivewindow"]).decode().strip()
+            )
+            subprocess.run(["import", "-window", win_id, full_path])
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            _open_file(full_path)
+            return
+
+    # Fallback to grabbing the screen region of the active window using PyQt
+    app = QApplication.instance() or QApplication(sys.argv)
+    widget = app.activeWindow()
+    screen = app.primaryScreen()
+    if widget:
+        geo = widget.frameGeometry()
+        screenshot = screen.grabWindow(0, geo.x(), geo.y(), geo.width(), geo.height())
+    else:
+        screenshot = screen.grabWindow(0)
+    screenshot.save(full_path, "png")
+    _open_file(full_path)
+
+
+# Backwards compatibility
+def capture_screen() -> None:
+    capture_window()
 
 
 if __name__ == "__main__":

--- a/grab-screen
+++ b/grab-screen
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from flicker.grab_screen import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- switch to `pynput.GlobalHotKeys` and add Win+Shift bindings
- use F6‑F8 as alternate hotkeys
- fall back to PyQt captures when `import`/`grim` are missing
- update docs with new keybinds
- refine capture functions and CLI options

## Testing
- `python -m py_compile flicker/*.py grab-screen`


------
https://chatgpt.com/codex/tasks/task_e_684f4f30856c8333b5d15536703f9422