### PR TITLE
Add packaging metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Aleksa Cakić
+Copyright (c) 2025 Aleksa Cakić
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include resources/flicker.png

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - WIN + Shift + D (or ALT + Shift + D / F8): Capture all screens
  - Screenshots are automatically copied to the clipboard and a desktop
    notification confirms the save location
+- A program icon is provided in `resources/flicker.png` and installed with the package.
 
 **Installation:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flicker"
+version = "0.1.0"
+description = "Screenshot hotkey listener"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Aleksa Cakić", email = "aleksa.cakic@gmail.com"}]
+license = {file = "LICENSE"}
+keywords = ["screenshots", "hotkeys"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+urls = {"Homepage" = "https://github.com/Alexayy/flicker"}
+
+dependencies = [
+    "PyQt5",
+    "pynput",
+]
+
+[tool.setuptools]
+packages = ["flicker"]
+
+[tool.setuptools.package-data]
+flicker = []
+
+[tool.setuptools.data-files]
+"share/flicker" = ["resources/flicker.png"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata
- include icon in distribution via MANIFEST.in
- note icon in README
- bump license year to 2025

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m build --wheel`

------
https://chatgpt.com/codex/tasks/task_e_685078b75ec883338c7b8544067cefb2