### PR TITLE
Fix Debian rules syntax

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,3 +1,3 @@
 #!/usr/bin/make -f
 %:
-dh $@ --with python3
+	dh $@ --with python3


### PR DESCRIPTION
## Summary
- ensure `packaging/debian/rules` uses a TAB for the dh line

## Testing
- `dpkg-buildpackage -us -uc -b` *(fails: Unmet build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68507b7188748333abd258e1a397465f