### PR TITLE
Enable tray icon service and autostart

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include resources/flicker.png
+include resources/flicker.desktop

--- a/flicker/app.py
+++ b/flicker/app.py
@@ -1,9 +1,44 @@
+"""Run Flicker as a background service with a tray icon."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from threading import Thread
+
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QApplication, QAction, QMenu, QSystemTrayIcon
+
 from .keyboard_listener import start_listener
 
 
-def main():
-    print("FLICKER starting...")
-    start_listener()
+def _icon_path() -> Path:
+    """Return the path to the installed icon."""
+    dev_path = Path(__file__).resolve().parent.parent / "resources" / "flicker.png"
+    if dev_path.exists():
+        return dev_path
+    return Path("/usr/share/flicker/flicker.png")
+
+
+def main() -> None:
+    """Start the hotkey listener and display a tray icon."""
+    app = QApplication(sys.argv)
+
+    # Start listener in a background thread so the Qt event loop can run
+    listener_thread = Thread(target=start_listener, daemon=True)
+    listener_thread.start()
+
+    tray = QSystemTrayIcon(QIcon(str(_icon_path())), parent=None)
+    tray.setToolTip("Flicker screenshot service")
+
+    menu = QMenu()
+    quit_action = QAction("Quit", menu)
+    quit_action.triggered.connect(app.quit)  # type: ignore[arg-type]
+    menu.addAction(quit_action)
+    tray.setContextMenu(menu)
+    tray.show()
+
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/packaging/debian/flicker.install
+++ b/packaging/debian/flicker.install
@@ -1,0 +1,1 @@
+../flicker.service usr/lib/systemd/user/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,4 @@ flicker = []
 
 [tool.setuptools.data-files]
 "share/flicker" = ["resources/flicker.png"]
+"etc/xdg/autostart" = ["resources/flicker.desktop"]

--- a/resources/flicker.desktop
+++ b/resources/flicker.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Flicker
+Exec=flicker
+Icon=/usr/share/flicker/flicker.png
+X-GNOME-Autostart-enabled=true
+NoDisplay=true


### PR DESCRIPTION
## Summary
- run Flicker with a PyQt5 tray icon
- install systemd user service and autostart desktop entry

## Testing
- `pip install -e .`
- `dpkg-buildpackage -us -uc -b`

------
https://chatgpt.com/codex/tasks/task_e_6850791c5c5c8333a1d21a325643c396