### PR TITLE
Fix Debian build rules

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,8 @@ Source: flicker
 Section: utils
 Priority: optional
 Maintainer: Aleksa Cakic <aleksa.cakic@gmail.com>
-Build-Depends: debhelper-compat (= 13), dh-python, python3, python3-setuptools, python3-pyqt5, python3-pynput
+Build-Depends: debhelper-compat (= 13), dh-python, pybuild-plugin-pyproject,
+ python3, python3-setuptools, python3-pyqt5, python3-pynput
 Standards-Version: 4.6.2
 Homepage: https://github.com/Alexayy/flicker
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,3 +1,3 @@
 #!/usr/bin/make -f
 %:
-	dh $@ --with python3 --buildsystem=pyproject
+	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
## Summary
- switch Debian packaging to use `pybuild`
- depend on `pybuild-plugin-pyproject`

## Testing
- `dpkg-buildpackage -us -uc -b`

------
https://chatgpt.com/codex/tasks/task_e_68508cf1de4c83339a3f1711716f5fd2