### PR TITLE
Add python3-build to build dependencies

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Aleksa Cakic <aleksa.cakic@gmail.com>
 Build-Depends: debhelper-compat (= 13), dh-python, pybuild-plugin-pyproject,
- python3, python3-setuptools, python3-pyqt5, python3-pynput
+ python3, python3-setuptools, python3-pyqt5, python3-pynput,
+ python3-build
 Standards-Version: 4.6.2
 Homepage: https://github.com/Alexayy/flicker
 


### PR DESCRIPTION
## Summary
- include `python3-build` in Debian Build-Depends

## Testing
- `dpkg-buildpackage -us -uc -b`

------
https://chatgpt.com/codex/tasks/task_e_68508f42098c8333a840560a9e7d0025