### PR TITLE
Add FLICKER_DIR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 **Features:**
 
 - Capture full screen, specific windows, or custom selections with ease.
-- Save screenshots in a dedicated `Pictures/FLICKERs` folder for effortless organization.
+ - Save screenshots in a dedicated `Pictures/FLICKERs` folder by default.
+ - Set the `FLICKER_DIR` environment variable to use a custom save location.
 - Support for both X11 and Wayland display servers.
 - Intuitive keyboard shortcuts for lightning-fast capture:
     - WIN + Shift + S (or ALT + Shift + S / F6): Capture a selection

--- a/flicker/screenshot.py
+++ b/flicker/screenshot.py
@@ -104,8 +104,12 @@ def get_session_type():
 
 
 def generate_file_path(filename_prefix="screenshot"):
-    home_dir = os.path.expanduser('~')
-    save_path = os.path.join(home_dir, 'Pictures', 'FLICKERs')
+    save_dir = os.getenv("FLICKER_DIR")
+    if save_dir:
+        save_path = os.path.expanduser(save_dir)
+    else:
+        home_dir = os.path.expanduser('~')
+        save_path = os.path.join(home_dir, 'Pictures', 'FLICKERs')
     os.makedirs(save_path, exist_ok=True)
     timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
     filename = f"{filename_prefix}_{timestamp}.png"


### PR DESCRIPTION
## Summary
- allow custom screenshot directory via `FLICKER_DIR`
- document the new environment variable in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68508f47dd5c8333a2af3fe6739159db