### PR TITLE
Add linter workflow and docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install flake8
+      - name: Run flake8
+        run: make lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,15 @@ Thank you for your interest in improving **Flicker**! This document describes ho
    ```bash
    pip install -r flicker/requirements.txt
    ```
-4. **Run Flicker** to verify everything works:
+4. **Install developer tools** (optional)
+   ```bash
+   pip install flake8
+   ```
+5. **Run the linter** to check code style:
+   ```bash
+   make lint
+   ```
+6. **Run Flicker** to verify everything works:
    ```bash
    python -m flicker.app
    ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint
+
+lint:
+	flake8 flicker


### PR DESCRIPTION
## Summary
- add a basic Makefile with a `lint` command
- document how to run the linter
- run flake8 in GitHub Actions

## Testing
- `make lint` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68508f48f7c4833388bbdc292d166164