### PR TITLE
docs: add Debian package build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@
    ```
    The package declares dependencies on `PyQt5` and `pynput`, so `apt-get -f install` will automatically fetch them if they are not present.
 
+### Building the Debian package
+
+To build a Debian package from this source tree install the required build
+dependencies and run the Debian tools from the packaging directory:
+
+```bash
+cd packaging/debian
+sudo apt-get build-dep .
+# or install the helper
+sudo apt-get install python3-build
+dpkg-buildpackage -us -uc -b
+```
+
+The resulting `.deb` will appear one directory above `packaging/debian`.
+
 **Usage:**
 
 1. Launch the application:


### PR DESCRIPTION
## Summary
- document Debian package build procedure in README

## Testing
- `flake8 flicker` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68519652f2dc83339804c35e88e62f3c