### PR TITLE
Update Fedora packaging

### DIFF
--- a/packaging/fedora/flicker.spec
+++ b/packaging/fedora/flicker.spec
@@ -24,12 +24,18 @@ Flicker provides global hotkeys for taking screenshots on Linux.
 
 %install
 %py3_install
+install -Dm644 flicker.service "%{buildroot}%{_unitdir}/flicker.service"
+install -Dm644 resources/flicker.png "%{buildroot}%{_datadir}/flicker/flicker.png"
+install -Dm644 resources/flicker.desktop "%{buildroot}%{_sysconfdir}/xdg/autostart/flicker.desktop"
 
 %files
 %license LICENSE
 %doc README.md
 %{_bindir}/grab-screen
 %{python3_sitelib}/flicker*
+%{_unitdir}/flicker.service
+%{_datadir}/flicker/flicker.png
+%{_sysconfdir}/xdg/autostart/flicker.desktop
 
 %changelog
 * Mon Jan 01 2025 Aleksa Cakic <aleksa.cakic@gmail.com> - 0.1-1


### PR DESCRIPTION
## Summary
- update Fedora spec to install service file
- install icon and desktop autostart file

## Testing
- `make lint` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68519653667483338a2118ec4084a5fc