### PR TITLE
Fix Debian build dependencies

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+flicker (0.1-2) unstable; urgency=medium
+
+  * Add missing build dependencies for pyproject builds.
+
+ -- Aleksa Cakic <aleksa.cakic@gmail.com>  Tue, 17 Jun 2025 16:24:36 +0000
+
 flicker (0.1-1) unstable; urgency=medium
 
   * Initial package

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,13 @@ Source: flicker
 Section: utils
 Priority: optional
 Maintainer: Aleksa Cakic <aleksa.cakic@gmail.com>
-Build-Depends: debhelper-compat (= 13), dh-python, python3, python3-setuptools, python3-pyqt5, python3-pynput
+Build-Depends: debhelper-compat (= 13), dh-python,
+ python3-all,
+ python3-setuptools,
+ python3-build,
+ python3-installer,
+ python3-pyqt5,
+ python3-pynput
 Standards-Version: 4.6.2
 Homepage: https://github.com/Alexayy/flicker
 


### PR DESCRIPTION
## Summary
- add python build requirements to `debian/control`
- note changes in `debian/changelog`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `dpkg-buildpackage -us -uc -b` *(fails: Unmet build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685196820ef88333a53cb832a35bc272