### PR TITLE
Fix Debian build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ To build a Debian package from this source tree install the required build
 dependencies and run the Debian tools from the packaging directory:
 
 ```bash
-cd packaging/debian
+cd packaging
 sudo apt-get build-dep .
 # or install the helper
 sudo apt-get install python3-build
 dpkg-buildpackage -us -uc -b
 ```
 
-The resulting `.deb` will appear one directory above `packaging/debian`.
+The resulting `.deb` will appear one directory above `packaging`.
 
 **Usage:**
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,3 +1,3 @@
 #!/usr/bin/make -f
 %:
-	dh $@ --with python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild --sourcedirectory=..


### PR DESCRIPTION
## Summary
- update the Debian `rules` file so `pybuild` uses the project root
- correct README build instructions to run from `packaging`

## Testing
- `dpkg-buildpackage -us -uc -b` *(fails: Unmet build dependencies)*
- `flake8 flicker` *(fails: E501 line too long, E302 expected 2 blank lines)*

------
https://chatgpt.com/codex/tasks/task_e_685197c399ec833385f332210a67b7a2