### PR TITLE
Fix tab indentation in packaging rules

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,3 +1,3 @@
 #!/usr/bin/make -f
 %:
-    dh $@ --with python3 --buildsystem=pybuild --sourcedirectory=..
+	dh $@ --with python3 --buildsystem=pybuild --sourcedirectory=..


### PR DESCRIPTION
## Summary
- ensure packaging `debian/rules` uses a single tab for `dh`

## Testing
- `cat -n -t packaging/debian/rules`


------
https://chatgpt.com/codex/tasks/task_e_6851ad0ec6ac8333879388c977d7eaa7