### PR TITLE
Fix AppImage builder script path

### DIFF
--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -4,9 +4,17 @@ AppDir:
   app_info:
     id: com.github.flicker
     name: Flicker
-    icon: flicker
+    icon: flicker.png
     version: "0.1"
     exec: usr/bin/python3
     exec_args: -m flicker.app
+  runtime:
+    arch: ["x86_64"]
+  files:
+    include:
+      - ../../resources/flicker.png
 script:
-  - pip3 install --prefix="$APPDIR/usr" ..
+  - pip3 install --prefix="$TARGET_APPDIR/usr" ../..
+  - mkdir -p "$TARGET_APPDIR/usr/bin"
+  - cp /usr/bin/python3 "$TARGET_APPDIR/usr/bin/"
+  - install -Dm644 ../../resources/flicker.png "$TARGET_APPDIR/usr/share/icons/hicolor/256x256/apps/flicker.png"


### PR DESCRIPTION
## Summary
- fix AppImage script to install from repo root
- copy Python interpreter and icon into AppDir
- specify runtime arch for AppImage build

## Testing
- `appimage-builder --recipe AppImageBuilder.yml`

------
https://chatgpt.com/codex/tasks/task_e_6851b9f559a88333b5c58ac59d48c765