### PR TITLE
Add AppImage build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@
      Download the `.AppImage` from the releases page, mark it as executable and
      run it directly.
 
+     To build your own AppImage:
+     1. Install `appimage-builder` (requires Python 3 and FUSE to run AppImages).
+     2. Run:
+        ```bash
+        appimage-builder --recipe packaging/appimage/AppImageBuilder.yml
+        ```
+
 **Usage:**
 
 1. Launch the application:


### PR DESCRIPTION
## Summary
- document building an AppImage with `appimage-builder`

## Testing
- `make lint` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6851b9f742ac8333a64e676fe4085812